### PR TITLE
Fixed strict aliasing violation.

### DIFF
--- a/include/boost/functional/hash/detail/hash_float.hpp
+++ b/include/boost/functional/hash/detail/hash_float.hpp
@@ -68,7 +68,7 @@ namespace boost
             std::size_t seed = 0;
 
             if (length >= sizeof(std::size_t)) {
-                seed = *(std::size_t*) ptr;
+                std::memcpy(&seed, ptr, sizeof(std::size_t));
                 length -= sizeof(std::size_t);
                 ptr += sizeof(std::size_t);
 


### PR DESCRIPTION
Changed C-style cast and dereference to std::memcpy.  Exactly mirrors other code already in the file.