### PR TITLE
replace members of std::allocate which are deprecated in c++17 by the…

### DIFF
--- a/factory/test/factory_with_allocator.cpp
+++ b/factory/test/factory_with_allocator.cpp
@@ -13,6 +13,11 @@
 #include <memory>
 #include <boost/shared_ptr.hpp>
 
+#ifdef BOOST_MSVC
+// none of the deprecated members of std::allocate are used here
+# pragma warning(disable:4996) // Various members of std::allocator are deprecated in C++17
+#endif
+
 using std::size_t;
 
 class sum 

--- a/include/boost/functional/factory.hpp
+++ b/include/boost/functional/factory.hpp
@@ -74,14 +74,23 @@ namespace boost
 
     template< class Pointer, class Allocator, factory_alloc_propagation AP >
     class factory
+#if defined(BOOST_NO_CXX11_ALLOCATOR)
         : private Allocator::template rebind< typename boost::pointee<
             typename boost::remove_cv<Pointer>::type >::type >::other
+#else
+        : private std::allocator_traits<Allocator>::template rebind_alloc<
+            typename boost::pointee< typename boost::remove_cv<Pointer>::type >::type >
+#endif
     {
       public:
         typedef typename boost::remove_cv<Pointer>::type result_type;
         typedef typename boost::pointee<result_type>::type value_type;
 
+#if defined(BOOST_NO_CXX11_ALLOCATOR)
         typedef typename Allocator::template rebind<value_type>::other
+#else
+        typedef typename std::allocator_traits<Allocator>::template rebind_alloc<value_type>
+#endif
             allocator_type;
 
         explicit factory(allocator_type const & a = allocator_type())


### PR DESCRIPTION
…ir cousins from std::allocator_traits.

Signed-off-by: Daniela Engert <dani@ngrt.de>