### PR TITLE
Added boost::identity

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -45,6 +45,9 @@ install:
   - cd boost
   - git submodule update --init tools/build
   - git submodule update --init libs/config
+  - git submodule update --init libs/move
+  - git submodule update --init libs/mpl
+  - git submodule update --init libs/container
   - git submodule update --init tools/boostdep
   - xcopy /s /e /q %APPVEYOR_BUILD_FOLDER% libs\functional\
   - python tools/boostdep/depinst/depinst.py -I forward/test -I factory/test -I overloaded_function/test functional

--- a/.travis.yml
+++ b/.travis.yml
@@ -282,6 +282,9 @@ install:
   - cd boost
   - git submodule update --init tools/build
   - git submodule update --init libs/config
+  - git submodule update --init libs/move
+  - git submodule update --init libs/mpl
+  - git submodule update --init libs/container
   - git submodule update --init tools/boostdep
   - mkdir -p libs/functional
   - cp -r $TRAVIS_BUILD_DIR/* libs/functional

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,8 @@ target_include_directories(boost_functional INTERFACE include)
 target_link_libraries(boost_functional
   INTERFACE
     Boost::config
+    Boost::move
+    Boost::container
     Boost::core
     Boost::function
     Boost::function_types

--- a/identity.html
+++ b/identity.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+
+<html>
+<head>
+  <meta http-equiv="Content-Language" content="en-us">
+  <meta http-equiv="Content-Type" content="text/html; charset=us-ascii">
+
+  <title>Boost Function Object Adapter Library</title>
+</head>
+
+<body bgcolor="#FFFFFF" text="#000000">
+  <table border="1" bgcolor="#007F7F" cellpadding="2" summary="">
+    <tr>
+      <td bgcolor="#FFFFFF"><img src="../../boost.png" alt=
+      "boost.png (6897 bytes)" width="277" height="86"></td>
+
+      <td><a href="../../index.htm"><font face="Arial" color=
+      "#FFFFFF"><big>Home</big></font></a></td>
+
+      <td><a href="../libraries.htm"><font face="Arial" color=
+      "#FFFFFF"><big>Libraries</big></font></a></td>
+
+      <td><a href="http://www.boost.org/people/people.htm"><font face="Arial" color=
+      "#FFFFFF"><big>People</big></font></a></td>
+
+      <td><a href="http://www.boost.org/more/faq.htm"><font face="Arial" color=
+      "#FFFFFF"><big>FAQ</big></font></a></td>
+
+      <td><a href="../../more/index.htm"><font face="Arial" color=
+      "#FFFFFF"><big>More</big></font></a></td>
+    </tr>
+  </table>
+
+  <h1>Identity</h1>
+
+  <p>The header <a href="../../boost/functional.hpp">functional.hpp</a>
+  provides a function object type whose <tt>operator()</tt> returns its argument unchanged:<br></p>
+
+  <ul>
+    <li><tt>identity</tt></li>
+  </ul>
+
+  <p>This is a C++03 implementation of C++20's <tt>std::identity</tt>.<br></p>
+
+  <h3>Usage</h3>
+
+  <p>Identity serves as the default projection in constrained algorithms. Its direct usage is usually not needed. For example,</p>
+
+  <blockquote>
+    <pre>
+template&lt;typename Projection = boost::identity&gt;
+struct projected_range_printer
+{
+    template&lt;typename Iterator&gt;
+    void print(Iterator b, Iterator e, Projection proj = Projection()) { ... }
+};
+...
+std::vector&lt;std::string&gt; c;
+...
+projected_range_printer&lt;&gt;().print(c.begin(), c.end());
+</pre>
+  </blockquote>
+
+  <h3>Argument And Return Types</h3>
+
+  <p>The "ISO/IEC 14882:2020" C++ Standard defines identity like this:</p>
+
+  <blockquote>
+    <pre>
+struct identity {
+  template&lt;class T&gt;
+  constexpr <strong>T&amp;&amp;</strong> operator()(<strong>T&amp;&amp;</strong> t) const noexcept;
+  using is_transparent = unspecified ;
+};
+</pre>
+  </blockquote>
+
+  <p></p>
+
+  <h3>Additional Types Defined</h3>
+
+  <h4><tt>is_transparent</tt></h4>
+
+  <p>This member type indicates to the caller that this function object is a <i>transparent</i> function object: it accepts arguments of arbitrary types and uses perfect forwarding(or its emulation in C++03), which avoids unnecessary copying and conversion when the function object is used in heterogeneous context, or with rvalue arguments. In particular, template functions such as <tt>std::set::find</tt> and <tt>std::set::lower_bound</tt> make use of this member type on their Compare types.</p>
+  <hr>
+
+  <p><a href="http://validator.w3.org/check?uri=referer"><img border="0" src=
+  "../../doc/images/valid-html401.png" alt="Valid HTML 4.01 Transitional"
+  height="31" width="88"></a></p>
+
+  <p>Revised 
+  <!--webbot bot="Timestamp" s-type="EDITED" s-format="%d %B, %Y" startspan -->02
+  December, 2006<!--webbot bot="Timestamp" endspan i-checksum="38510" --></p>
+
+  <p><i>Copyright &copy; 2000 Cadenza New Zealand Ltd.</i></p>
+
+  <p><i>Distributed under the Boost Software License, Version 1.0. (See
+  accompanying file <a href="../../LICENSE_1_0.txt">LICENSE_1_0.txt</a> or
+  copy at <a href=
+  "http://www.boost.org/LICENSE_1_0.txt">http://www.boost.org/LICENSE_1_0.txt</a>)</i></p>
+</body>
+</html>

--- a/include/boost/functional.hpp
+++ b/include/boost/functional.hpp
@@ -14,6 +14,7 @@
 
 #include <boost/config.hpp>
 #include <boost/call_traits.hpp>
+#include <boost/functional/identity.hpp>
 #include <functional>
 
 namespace boost

--- a/include/boost/functional/identity.hpp
+++ b/include/boost/functional/identity.hpp
@@ -1,0 +1,70 @@
+/*=============================================================================
+    Copyright (c) 2021 Denis Mikhailov
+  
+    Use modification and distribution are subject to the Boost Software 
+    License, Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+    http://www.boost.org/LICENSE_1_0.txt).  
+==============================================================================*/
+
+#ifndef BOOST_FUNCTIONAL_IDENTITY_HPP_INCLUDED 
+#define BOOST_FUNCTIONAL_IDENTITY_HPP_INCLUDED
+
+#include <boost/config.hpp>
+#include <boost/move/core.hpp>
+#include <boost/move/utility_core.hpp>
+#include <boost/mpl/if.hpp>
+
+namespace boost
+{
+    namespace functional { namespace detail {
+        template<class T>
+        struct move_reference
+        {
+            #if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES) || defined(BOOST_MOVE_DOXYGEN_INVOKED)
+            typedef T &&                                                 type;
+            #else
+            typedef typename ::boost::mpl::if_
+                < ::boost::has_move_emulation_enabled<T>
+                , ::boost::rv<T>&
+                , T & >::type                                            type;
+            #endif
+        };
+    }}
+
+    struct identity
+    {
+        typedef void is_transparent;
+
+        template<class> struct result;
+
+        template<class F, class T>
+        struct result<F(T)>
+            : functional::detail::move_reference<T>
+        {};
+        
+        template<class F, class T>
+        struct result<F(BOOST_RV_REF(T))>
+            : functional::detail::move_reference<T>
+        {};
+        
+        template<class F, class T>
+        struct result<F(T&)> {
+            typedef T& type;
+        };
+    
+        template<class T>
+        BOOST_CONSTEXPR typename result<identity(BOOST_RV_REF(T))>::type operator()( BOOST_RV_REF(T) t ) const BOOST_NOEXCEPT
+        {
+            return ::boost::move(t);
+        }
+        
+        template<class T>
+        BOOST_CONSTEXPR typename result<identity(T&)>::type operator()(T& t) const BOOST_NOEXCEPT
+        {
+            return t;
+        }
+    };
+} // boost
+
+#endif // BOOST_FUNCTIONAL_IDENTITY_HPP_INCLUDED
+

--- a/index.html
+++ b/index.html
@@ -52,11 +52,21 @@
     "ptr_fun.html">ptr_fun</a></tt> with the adapters in this library.</li>
   </ol>
 
+  This header also provides some C++03 implementations of function objects from a newer C++ Standards.
+
   <h3>Contents</h3>
 
   <p>The header contains the following function and class templates:</p>
 
   <table border="1" cellpadding="5" summary="">
+    <tr>
+      <th align="left"><a href="identity.html">Identity</a></th>
+
+      <td valign="top"><tt>identity</tt></td>
+
+      <td valign="top">Function object that returns its argument unchanged.</td>
+    </tr>
+
     <tr>
       <th align="left"><a href="function_traits.html">Function object
       traits</a></th>

--- a/test/function_test.cpp
+++ b/test/function_test.cpp
@@ -129,6 +129,9 @@
 #include <iterator>
 #include <string>
 #include <vector>
+#include <boost/container/list.hpp>
+#include <boost/container/vector.hpp>
+#include <boost/container/string.hpp>
 
 class Person
 {
@@ -169,6 +172,16 @@ namespace
     {
         p.set_name(name);
     }
+
+    template<typename T1, typename T2>
+    void print (T1 const rem, T2 const& seq) {
+        std::cout << rem;
+        for (typename T2::const_iterator it=seq.begin();it!=seq.end();++it)
+        {
+            std::cout << *it << ' ';
+        }
+        std::cout << '\n';
+    };
 }
 
 int main()
@@ -328,6 +341,27 @@ int main()
     std::cout << '\n';
     std::transform(v1.begin(), v1.end(), std::ostream_iterator<std::string>(std::cout, " "),
                    boost::mem_fun_ref(&Person::clear_name));    
+
+    // identity
+    std::cout << '\n';
+    boost::container::list<boost::container::string> s;
+    s.push_back("one");
+    s.push_back("two");
+    s.push_back("three");
+
+    boost::container::vector<boost::container::string> v1;
+    std::transform(s.begin(), s.end(), std::back_inserter(v1), boost::identity()); // copy
+
+
+    boost::container::vector<boost::container::string> v2;
+    std::transform(boost::make_move_iterator(s.begin()),
+              boost::make_move_iterator(s.end()),
+              boost::back_move_inserter(v2),
+              boost::identity()); // move
+
+    print("v1 now holds: ", v1);
+    print("v2 now holds: ", v2);
+    print("original list now holds: ", s);
 
     std::cout << '\n';
     return 0;


### PR DESCRIPTION
I don't know if it makes sense to suggest any changes to this outdated repository, but why not give it a try.
This code is needed to be used on the side of the Boost Fusion library, the corresponding topic was raised in the adjacent repository:
https://github.com/boostorg/core/issues/102
Thank you for your attention to me.