### PR TITLE
Identity result_of

### DIFF
--- a/include/boost/functional/identity.hpp
+++ b/include/boost/functional/identity.hpp
@@ -17,13 +17,7 @@ namespace boost {
 
 struct identity {
     typedef void is_transparent;
-
-#if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
-    template<class T>
-    BOOST_CONSTEXPR T&& operator()(T&& value) const BOOST_NOEXCEPT {
-        return std::forward<T>(value);
-    }
-#else
+    
     template<class> struct result;
 
     template<class F, class T>
@@ -36,6 +30,32 @@ struct identity {
         typedef T& type;
     };
 
+#if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
+    template<class F, class T>
+    struct result<F(T)> {
+        typedef T&& type;
+    };
+
+    template<class F, class T>
+    struct result<F(const T&&)> {
+        typedef const T&& type;
+    };
+
+    template<class F, class T>
+    struct result<F(T&&)> {
+        typedef T&& type;
+    };
+
+    template<class T>
+    BOOST_CONSTEXPR T&& operator()(T&& value) const BOOST_NOEXCEPT {
+        return std::forward<T>(value);
+    }
+#else
+    template<class F, class T>
+    struct result<F(T)> {
+        typedef const T& type;
+    };
+    
     template<class T>
     BOOST_CONSTEXPR const T& operator()(const T& value) const BOOST_NOEXCEPT {
         return value;

--- a/include/boost/functional/identity.hpp
+++ b/include/boost/functional/identity.hpp
@@ -24,6 +24,18 @@ struct identity {
         return std::forward<T>(value);
     }
 #else
+    template<class> struct result;
+
+    template<class F, class T>
+    struct result<F(const T&)> {
+        typedef const T& type;
+    };
+
+    template<class F, class T>
+    struct result<F(T&)> {
+        typedef T& type;
+    };
+
     template<class T>
     BOOST_CONSTEXPR const T& operator()(const T& value) const BOOST_NOEXCEPT {
         return value;

--- a/include/boost/functional/identity.hpp
+++ b/include/boost/functional/identity.hpp
@@ -2,6 +2,8 @@
 Copyright 2021 Glen Joseph Fernandes
 (glenjofe@gmail.com)
 
+Copyright (c) 2022 Denis Mikhailov
+
 Distributed under the Boost Software License, Version 1.0.
 (http://www.boost.org/LICENSE_1_0.txt)
 */

--- a/test/identity_rvalue_test.cpp
+++ b/test/identity_rvalue_test.cpp
@@ -9,6 +9,8 @@ Distributed under the Boost Software License, Version 1.0.
 #if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
 #include <boost/functional/identity.hpp>
 #include <boost/core/lightweight_test.hpp>
+#include <boost/utility.hpp>
+#include <boost/type_traits/is_same.hpp>
 #include <algorithm>
 #include <iterator>
 #include <string>
@@ -61,10 +63,19 @@ void algorithm_test()
     BOOST_TEST(v3 == v1);
 }
 
+void result_of_test()
+{
+    BOOST_TEST(( boost::is_same<
+            boost::result_of< boost::identity(int&&) >::type, int&& >::value ));
+    BOOST_TEST(( boost::is_same<
+            boost::result_of< boost::identity(const int&&) >::type, const int&& >::value ));
+}
+
 int main()
 {
     simple_test();
     algorithm_test();
+    result_of_test();
     return boost::report_errors();
 }
 #else

--- a/test/identity_rvalue_test.cpp
+++ b/test/identity_rvalue_test.cpp
@@ -2,6 +2,8 @@
 Copyright 2021 Glen Joseph Fernandes
 (glenjofe@gmail.com)
 
+Copyright (c) 2022 Denis Mikhailov
+
 Distributed under the Boost Software License, Version 1.0.
 (http://www.boost.org/LICENSE_1_0.txt)
 */

--- a/test/identity_rvalue_test.cpp
+++ b/test/identity_rvalue_test.cpp
@@ -9,8 +9,8 @@ Distributed under the Boost Software License, Version 1.0.
 #if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
 #include <boost/functional/identity.hpp>
 #include <boost/core/lightweight_test.hpp>
-#include <boost/utility.hpp>
 #include <boost/type_traits/is_same.hpp>
+#include <boost/utility/result_of.hpp>
 #include <algorithm>
 #include <iterator>
 #include <string>

--- a/test/identity_test.cpp
+++ b/test/identity_test.cpp
@@ -7,8 +7,8 @@ Distributed under the Boost Software License, Version 1.0.
 */
 #include <boost/functional/identity.hpp>
 #include <boost/core/lightweight_test.hpp>
-#include <boost/utility.hpp>
 #include <boost/type_traits/is_same.hpp>
+#include <boost/utility/result_of.hpp>
 #include <algorithm>
 #include <iterator>
 #include <string>

--- a/test/identity_test.cpp
+++ b/test/identity_test.cpp
@@ -7,6 +7,8 @@ Distributed under the Boost Software License, Version 1.0.
 */
 #include <boost/functional/identity.hpp>
 #include <boost/core/lightweight_test.hpp>
+#include <boost/utility.hpp>
+#include <boost/type_traits/is_same.hpp>
 #include <algorithm>
 #include <iterator>
 #include <string>
@@ -64,9 +66,18 @@ void algorithm_test()
     BOOST_TEST(v2 == v1);
 }
 
+void result_of_test()
+{
+    BOOST_TEST(( boost::is_same<
+            boost::result_of< boost::identity(int&) >::type, int& >::value ));
+    BOOST_TEST(( boost::is_same<
+            boost::result_of< boost::identity(const int&) >::type, const int& >::value ));
+}
+
 int main()
 {
     simple_test();
     algorithm_test();
+    result_of_test();
     return boost::report_errors();
 }

--- a/test/identity_test.cpp
+++ b/test/identity_test.cpp
@@ -2,6 +2,8 @@
 Copyright 2021 Glen Joseph Fernandes
 (glenjofe@gmail.com)
 
+Copyright (c) 2022 Denis Mikhailov
+
 Distributed under the Boost Software License, Version 1.0.
 (http://www.boost.org/LICENSE_1_0.txt)
 */

--- a/test/identity_test.cpp
+++ b/test/identity_test.cpp
@@ -72,6 +72,13 @@ void result_of_test()
             boost::result_of< boost::identity(int&) >::type, int& >::value ));
     BOOST_TEST(( boost::is_same<
             boost::result_of< boost::identity(const int&) >::type, const int& >::value ));
+#if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
+    BOOST_TEST(( boost::is_same<
+            boost::result_of< boost::identity(int) >::type, int&& >::value ));
+#else
+    BOOST_TEST(( boost::is_same<
+            boost::result_of< boost::identity(int) >::type, const int& >::value ));
+#endif
 }
 
 int main()


### PR DESCRIPTION
Added the ability to use `boost::result_of` metafunction with `boost::identity` functional object types, for example:
```
typedef boost::result_of< boost::identity(int&) >::type type00;
typedef boost::result_of< boost::identity(const int&) >::type type01;
// etc..
```
This ability required by **Boost Fusion** side, and this PR need  to me to close this PR: https://github.com/boostorg/fusion/pull/240