### PR TITLE
refactor: use boost/core/ref over boost/ref

### DIFF
--- a/include/boost/functional/lightweight_forward_adapter.hpp
+++ b/include/boost/functional/lightweight_forward_adapter.hpp
@@ -20,7 +20,7 @@
 #   include <boost/preprocessor/facilities/intercept.hpp>
 
 #   include <boost/utility/result_of.hpp>
-#   include <boost/ref.hpp>
+#   include <boost/core/ref.hpp>
 
 #   ifndef BOOST_FUNCTIONAL_LIGHTWEIGHT_FORWARD_ADAPTER_MAX_ARITY
 #     define BOOST_FUNCTIONAL_LIGHTWEIGHT_FORWARD_ADAPTER_MAX_ARITY 10


### PR DESCRIPTION
The later is deprecated.

```cpp
// The header file at this path is deprecated;
// use boost/core/ref.hpp instead.

include <boost/core/ref.hpp>
```